### PR TITLE
Fix crash

### DIFF
--- a/src/Cyril/Lang/CyrilLoad.h
+++ b/src/Cyril/Lang/CyrilLoad.h
@@ -32,7 +32,7 @@ public:
   virtual void eval(CyrilState &_s) {
     //cout << "Load " << loc << ": " << (*_s.sym)[loc] << endl;
     //cout << _s.sym->count(loc) << endl;
-      if ((*_s.sym)[loc] == 0 && (*_s.parent->sym)[loc] != 0) {
+      if ((*_s.sym)[loc] == 0 && (_s.parent != 0) && (*_s.parent->sym)[loc] != 0) {
           _s.stk->push((*_s.parent->sym)[loc]);
       }
       else {


### PR DESCRIPTION
This code `(*_s.parent->sym)[loc] != 0)` was causing an error when I've built the project myself, it's happening on first check here.

I'm not sure if I understand this correctly - it seems that sometimes there's no `parent` available for `_s`. Adding additional `(_s.parent != 0)` check prevents the error, but I'm not sure if it sill works as indented with frames and particles.